### PR TITLE
Update v2.ahk

### DIFF
--- a/v2.ahk
+++ b/v2.ahk
@@ -1,55 +1,15 @@
 ; <COMPILER: v1.1.24.01>
-Box_Init(C="FF0000") {
-Gui, 96: -Caption +ToolWindow +E0x20
-Gui, 96: Color, % C
-Gui, 97: -Caption +ToolWindow +E0x20
-Gui, 97: Color, % C
-Gui, 98: -Caption +ToolWindow +E0x20
-Gui, 98: Color, % C
-Gui, 99: -Caption +ToolWindow +E0x20
-Gui, 99: Color, % C
-}
-Box_Draw(X, Y, W, H, T="1", O="I") {
-If(W < 0)
-X += W, W *= -1
-If(H < 0)
-Y += H, H *= -1
-If(T >= 2)
-{
-If(O == "O")
-X -= T, Y -= T, W += T, H += T
-If(O == "C")
-X -= T / 2, Y -= T / 2
-If(O == "I")
-W -= T, H -= T
-}
-Gui, 96: Show, % "x" X " y" Y " w" W " h" T " NA", Horizontal 1
-Gui, 96:+AlwaysOnTop
-Gui, 98: Show, % "x" X " y" Y + H " w" W " h" T " NA", Horizontal 2
-Gui, 98:+AlwaysOnTop
-Gui, 97: Show, % "x" X " y" Y " w" T " h" H " NA", Vertical 1
-Gui, 97:+AlwaysOnTop
-Gui, 99: Show, % "x" X + W " y" Y " w" T " h" H " NA", Vertical 2
-Gui, 99:+AlwaysOnTop
-}
-Box_Destroy() {
-Loop, 4
-Gui, % A_Index + 95 ":  Destroy"
-}
-Box_Hide() {
-Loop, 4
-Gui, % A_Index + 95 ":  Hide"
-}
-guif:
 #NoEnv
 #SingleInstance force
+#KeyHistory, 0
+ListLines, Off
+SetBatchLines, -1
+CoordMode, Pixel, Screen
 
-Firing := 0
-Gui Add, Text, x220 y25 w130 h30, Small Screen [F1]
-Gui Add, Text, x220 y45 w110 h30, Large Screen [F2]
+Gui Add, Text, x220 y25 w130 h30, Start [F1]
+; Gui Add, Text, x220 y45 w110 h30, Large Screen [F2]
 Gui Add, Text, x220 y65 w160 h30, Restart Program [F3]
 Gui Add, Text, x220 y85 w110 h30, Pause/Resume [F4]
-
 
 Gui Add, GroupBox, x10 y120 w160 h45, Speed
 Gui Add, GroupBox, x10 y10 w180 h100, Intro
@@ -66,12 +26,12 @@ Gui Add, Button, x230 y240 w100 h20 gsub2, Get lastest ver
 Gui Add, GroupBox, x8 y265 w187 h210, Misc
 Gui Add, CheckBox, x16 y288 w160 h20 voverlayActive, Overlay
 Gui Add, CheckBox, x16 y328 w160 h20 vreaper, Reaper Fast Reload
-Gui Add, Text, x16 y428 w160 h20, LtoRaddendOffset:
-Gui Add, Edit, x16 y448 w160 h20 vLtoRaddendOffset, 1.2
-Gui Add, Text, x16 y200 w33 h20, x-axis:
-Gui Add, Slider,x48 y200 w130 h25 vxrange Invert Tickinterval1 range1-4, 4
-Gui Add, Text, x16 y224 w35 h19, y-axis:
-Gui Add, Slider,x48 y224 w130 h25 vyrange Invert Tickinterval1 range1-4, 4
+; Gui Add, Text, x16 y428 w160 h20, LtoRaddendOffset:
+; Gui Add, Edit, x16 y448 w160 h20 vLtoRaddendOffset, 1.2
+; Gui Add, Text, x16 y200 w33 h20, x-axis:
+; Gui Add, Slider,x48 y200 w130 h25 vxrange Invert Tickinterval1 range1-4, 4
+; Gui Add, Text, x16 y224 w35 h19, y-axis:
+; Gui Add, Slider,x48 y224 w130 h25 vyrange Invert Tickinterval1 range1-4, 4
 Gui Add, Edit, x315 y140 w30 h20 vya, %pfya%
 Gui Add, Text, x280 y140 w35 h20, Y:
 Gui Add, Text, x208 y140 w35 h20, X:
@@ -79,12 +39,7 @@ Gui Add, Edit, x240 y140 w35 h20 vxa, %pfxa%
 Gui Add, GroupBox, x205 y120 w160 h45, Shoot 
 Gui Add, Text, x220 y300 w130 h150, `n`nThe software is just for fun`n`nYou should only use it for legal propose`n`n
 Gui Show, w372 h480, Overkill v1.4
-Loop {
-Gui, Submit, NoHide
-Sleep -1
-}
 Return
-
 
 sub1:
 {
@@ -106,133 +61,6 @@ MsgBox,  Applied
 Gui,Submit, Nohide
 return
 
-F1::
-#Persistent
-#KeyHistory, 0
-#NoEnv
-#HotKeyInterval 1
-#MaxHotkeysPerInterval 127
-#InstallKeybdHook
-#UseHook
-#SingleInstance, Force
-SetKeyDelay,-1, 8
-SetControlDelay, -1
-SetMouseDelay, 0
-SetWinDelay,-1
-SendMode, InputThenPlay
-SetBatchLines,-1
-ListLines, Off
-CoordMode, Mouse, Screen
-PID := DllCall("GetCurrentProcessId")
-Process, Priority, %PID%, Normal
-ZeroX := 640
-ZeroY := 360
-CFovX := 320
-CFovY := 200
-ScanL := 500
-ScanR := 800
-ScanT := 180
-ScanB := 400
-
-;UI parameters
-GuiControlget, rx
-GuiControlget, xa
-GuiControlget, ya
-GuiControlget, xrange
-GuiControlget, yrange
-
-;save profile
-GoSub saveProfile
-
-;detection box
-LargeX1 := 0 + (A_Screenwidth * (xrange/10))
-LargeY1 := 0 + (A_Screenheight * (yrange/10))-40
-LargeX2 := A_Screenwidth - (A_Screenwidth * (xrange/10))
-LargeY2 := A_Screenheight - (A_Screenheight * (yrange / 10))-75
-SmallX1 := LargeX1 + 40
-SmallY1 := LargeY1 
-SmallX2 := LargeX2 - 40
-SmallY2 := LargeY2 - 55
-
-;parameters used for pixel search, ideal ColVn should be 0, meaning that EMCol is the exact color of health bar
-EMCol := 0xFF0013
-ColVn := 2
-FoundFlag :=false
-
-if(overlayActive=1){
-Box_Init("FF0000")
-Box_Draw(LargeX1, LargeY1 , LargeX2-LargeX1, LargeY2-LargeY1)
-}
-
-Loop, {
-Gui,Submit, Nohide
-
-GoSub SearchBot
-GetKeyState, Mouse2, LButton, P
-if ( Mouse2 == "D" ) {
-
-GoSub GetAimOffset
-GoSub GetAimMoves
-GoSub MouseMoves
-
-}
-
-
-
-
-}
-
-MouseMoves:
-If ( Mouse2 == "D" ) {
-DllCall("mouse_event", uint, 1, int, MoveX, int, MoveY, uint, 0, int, 0)
-}
-Return
-
-
-
-GetAimOffset:
-Gui,Submit, Nohide
-headX :=1+xa
-headY := 19+ya*5
-AimX := AimPixelX - ZeroX +headX
-AimY := AimPixelY - ZeroY +headY
-If ( AimX+5 > 0) {
-DirX := rx / 10
-}
-If ( AimX+5 < 0) {
-DirX := (-rx) / 10
-}
-If ( AimY+2 > 0 ) {
-DirY := rx /10
-}
-If ( AimY+2 < 0 ) {
-DirY := (-rx) /10
-}
-AimOffsetX := AimX * DirX
-AimOffsetY := AimY * DirY
-Return
-
-
-
-GetAimMoves:
-RootX :=  AimOffsetX 
-RootY :=  AimOffsetY 
-MoveX := RootX * DirX
-MoveY := RootY * DirY
-Return
-
-SleepF:
-SleepDuration = 1
-TimePeriod = 1
-DllCall("Winmm\timeBeginPeriod", uint, TimePeriod)
-Iterations = 1
-StartTime := A_TickCount
-Loop, %Iterations% {
-DllCall("Sleep", UInt, TimePeriod)
-}
-DllCall("Winmm\timeEndPeriod", UInt, TimePeriod)
-Return
-
 DebugTool:
 MouseGetPos, MX, MY
 ToolTip, %AimOffsetX% | %AimOffsetY%
@@ -243,94 +71,32 @@ ToolTip, %MoveX% | %MoveY% || %MX% %MY%
 Return
 
 
-F2::
-#KeyHistory, 0
-#NoEnv
-#SingleInstance, Force
-SetBatchLines,-1
-ListLines, Off
+F1::
+Gui, Submit, NoHide
 
-;UI parameters
-GuiControlget, rx
-GuiControlget, xa
-GuiControlget, ya
-GuiControlget, xrange
-GuiControlget, yrange
+headX := 41 + xa*3
+headY := 77 + ya*5
 
 ;save profile
 GoSub saveProfile
 
-;detection box
-LargeX1 := (A_ScreenWidth)/2 - (A_ScreenWidth)/5
-LargeY1 := (A_ScreenHeight)/2 - (A_ScreenHeight)/4
-LargeX2 := (A_ScreenWidth)/2 + (A_ScreenWidth)/5
-LargeY2 := (A_ScreenHeight)/2 + (A_ScreenHeight)/4
-SmallX1 := LargeX1 + 60
-SmallY1 := LargeY1 
-SmallX2 := LargeX2 - 60
-SmallY2 := LargeY2 - 55
-
-
-;parameters used for pixel search, ideal ColVn should be 0, meaning that EMCol is the exact color of health bar
-EMCol := 0xFF0013
-ColVn := 0
-FoundFlag :=false
-Cnt:=0
 if(overlayActive=1){
 Box_Init("FF0000")
-Box_Draw(LargeX1, LargeY1 , LargeX2-LargeX1, LargeY2-LargeY1)
+Box_Draw((A_ScreenWidth)/2 - (A_ScreenWidth)/5, (A_ScreenHeight)/2 - (A_ScreenHeight)/4
+	, 2 * (A_ScreenWidth)/5, 2 * (A_ScreenHeight)/4)
 }
 
-Loop, {
-Gui,Submit, Nohide
+Init := new OverWatch(rx)
 
-
-GoSub SearchBot
-GetKeyState, Mouse2, LButton, P
-if ( Mouse2 == "D" ) {
-
-GoSub GetAimOffset1
-GoSub GetAimMoves1
-GoSub MouseMoves1
-
-}
-}
-
-
-
-
-MouseMoves1:
-DllCall("mouse_event", uint, 1, int, MoveX, int, MoveY, uint, 0, int, 0)
-Return
-
-
-
-SearchBot:
-Loop,
+Loop
 {
-	PixelSearch, AimPixelX, AimPixelY, LargeX1, LargeY1, LargeX2, LargeY2, EMCol, ColVn, Fast RGB
-} Until ErrorLevel = 0
+	If ( Init.Firing("LButton") )
+	{
+		Pos := Init.Search()
+		Init.Calc(Pos.X, Pos.Y, headX, headY)
+	}
+}
 Return
-
-
-
-GetAimOffset1:
-Gui,Submit, Nohide
-
-headX := 42+xa*3
-headY := 90+ya*5
-AimX := (AimPixelX - A_ScreenWidth/2 +headX) / (rx / 10)
-AimY := (AimPixelY - A_ScreenHeight/2 +headY) / (rx / 10)
-
-Return
-
-GetAimMoves1:
-If ( Abs(AimX) < 1 ) && ( Abs(AimY) < 3 )
-	Return
-MoveX := AimX
-MoveY := MoveY
-Return
-
 
 getProfile:
 file := FileOpen("overkill.conf", "r")
@@ -391,7 +157,6 @@ file.Close()
 return
 
 
-
 reload:
 SleepF1:
 SleepDuration = 1
@@ -419,3 +184,88 @@ return
 F3::
 Reload
 Return
+
+Box_Init(C="FF0000") {
+Gui, 96: -Caption +ToolWindow +E0x20
+Gui, 96: Color, % C
+Gui, 97: -Caption +ToolWindow +E0x20
+Gui, 97: Color, % C
+Gui, 98: -Caption +ToolWindow +E0x20
+Gui, 98: Color, % C
+Gui, 99: -Caption +ToolWindow +E0x20
+Gui, 99: Color, % C
+}
+Box_Draw(X, Y, W, H, T="1", O="I") {
+If(W < 0)
+X += W, W *= -1
+If(H < 0)
+Y += H, H *= -1
+If(T >= 2)
+{
+If(O == "O")
+X -= T, Y -= T, W += T, H += T
+If(O == "C")
+X -= T / 2, Y -= T / 2
+If(O == "I")
+W -= T, H -= T
+}
+Gui, 96: Show, % "x" X " y" Y " w" W " h" T " NA", Horizontal 1
+Gui, 96:+AlwaysOnTop
+Gui, 98: Show, % "x" X " y" Y + H " w" W " h" T " NA", Horizontal 2
+Gui, 98:+AlwaysOnTop
+Gui, 97: Show, % "x" X " y" Y " w" T " h" H " NA", Vertical 1
+Gui, 97:+AlwaysOnTop
+Gui, 99: Show, % "x" X + W " y" Y " w" T " h" H " NA", Vertical 2
+Gui, 99:+AlwaysOnTop
+}
+Box_Destroy() {
+Loop, 4
+Gui, % A_Index + 95 ":  Destroy"
+}
+Box_Hide() {
+Loop, 4
+Gui, % A_Index + 95 ":  Hide"
+}
+
+Class OverWatch
+{
+	__New(rx)
+	{
+		this.rx := rx
+		this.offset := rx / 10
+	}
+
+	Firing(Key)
+	{
+		Return GetKeyState(Key, "P")
+	}
+
+	Search()
+	{
+		Static X1 := (A_ScreenWidth)/2 - (A_ScreenWidth)/5
+		, Y1 := (A_ScreenHeight)/2 - (A_ScreenHeight)/4
+		, X2 := (A_ScreenWidth)/2 + (A_ScreenWidth)/5
+		, Y2 := (A_ScreenHeight)/2 + (A_ScreenHeight)/4
+		, ColorID := 0xFF0013, ColorVariation := 0
+
+		Loop
+		{
+			PixelSearch, OutputVarX, OutputVarY, X1, Y1, X2, Y2, ColorID, Variation, Fast RGB
+		} Until ErrorLevel = 0
+
+		Return {x: OutputVarX, y: OutputVarY}
+	}
+
+	Calc(x, y, headX, headY)
+	{
+		x := Round( (x - A_ScreenWidth/2 + headX) * this.offset )
+		y := Round( (y - A_ScreenHeight/2 + headY) * this.offset )
+
+		this.MouseMove(x, y)
+	}
+
+	MouseMove(x, y)
+	{
+		Return DllCall("mouse_event", "UInt", 0x01, "Int", x, "Int", y)
+	}
+}


### PR DESCRIPTION
**Added**
- New OverWatch class for future maintenance of the codes
```AutoHotkey
Class OverWatch
{
	__New(rx)
	{
		this.rx := rx
		this.offset := rx / 10
	}

	Firing(Key)
	{
		Return GetKeyState(Key, "P")
	}

	Search()
	{
		Static X1 := (A_ScreenWidth)/2 - (A_ScreenWidth)/5
		, Y1 := (A_ScreenHeight)/2 - (A_ScreenHeight)/4
		, X2 := (A_ScreenWidth)/2 + (A_ScreenWidth)/5
		, Y2 := (A_ScreenHeight)/2 + (A_ScreenHeight)/4
		, ColorID := 0xFF0013, ColorVariation := 0

		Loop
		{
			PixelSearch, OutputVarX, OutputVarY, X1, Y1, X2, Y2, ColorID, Variation, Fast RGB
		} Until ErrorLevel = 0

		Return {x: OutputVarX, y: OutputVarY}
	}

	Calc(x, y, headX, headY)
	{
		x := Round( (x - A_ScreenWidth/2 + headX) * this.offset )
		y := Round( (y - A_ScreenHeight/2 + headY) * this.offset )

		this.MouseMove(x, y)
	}

	MouseMove(x, y)
	{
		Return DllCall("mouse_event", "UInt", 0x01, "Int", x, "Int", y)
	}
}
```
**Removed**
- Small Screen [F1], Large Screen [F2] have been removed, there is no need to separate func by the size of the screen
``` AutoHotkey
Gui Add, Text, x220 y25 w130 h30, Small Screen [F1]
Gui Add, Text, x220 y45 w110 h30, Large Screen [F2]
...lots more
```
- x-axis and y-axis, since these were no longer needed
``` AutoHotkey
Gui Add, Text, x16 y200 w33 h20, x-axis:
Gui Add, Slider,x48 y200 w130 h25 vxrange Invert Tickinterval1 range1-4, 4
Gui Add, Text, x16 y224 w35 h19, y-axis:
Gui Add, Slider,x48 y224 w130 h25 vyrange Invert Tickinterval1 range1-4, 4
... lots more
```
- LtoRaddendOffset, I don't know what it is for?
``` AutoHotkey
Gui Add, Edit, x16 y448 w160 h20 vLtoRaddendOffset, 1.2
...
... + LtoRaddendOffset ;tested with 15 sensitivity, the addend should be larger than 1.3 when sensitivity is smaller than 15
```
- several unnecessary codes